### PR TITLE
Ignore preload link elements on css reload

### DIFF
--- a/src/figwheel/main/css_reload.cljc
+++ b/src/figwheel/main/css_reload.cljc
@@ -49,8 +49,9 @@
   (.makeUnique (guri/parse url)))
 
 (defn current-links []
-  (.call (.. js/Array -prototype -slice)
-         (.getElementsByTagName js/document "link")))
+  (->> (.getElementsByTagName js/document "link")
+       (.call (.. js/Array -prototype -slice))
+       (remove (comp #{"preload"} #(.-rel %)))))
 
 (defn truncate-url [url]
   (-> (first (string/split url #"\?"))


### PR DESCRIPTION
The DOM may contain preload link elements with the same href as a
stylesheet we're attempting to reload, e.g.:
```
<link rel="preload"    href="style.css">
<link rel="stylesheet" href="style.css">
```
Ignore these to make sure we update the stylesheet instead of the preload.