### PR TITLE
First attempt at Cursive specific documentation

### DIFF
--- a/docs/docs/cursive.md
+++ b/docs/docs/cursive.md
@@ -1,0 +1,41 @@
+---
+title: Cursive
+layout: docs
+category: docs
+order: 21
+---
+
+# Cursive
+
+Once you have become comfortable with figwheel-main, you may want to put some effort into integrating it with your preferred editor. This document will discusss how to get your project working nicely with Cursive for a few different configurations.
+
+
+# CLJS Only 
+
+Support for deps.edn and the CLI is currently only available in the Early Access versions of Cursive and it is not yet able to run figwheel-main directly, so for now we will focus on Leiningen.
+ 
+We're going to start with the same build that we used in the [create-a-build] documentation. Set up your project as described there and confirm that you can run it using
+ 
+```shell
+$ lein fig -- -b -r
+```
+> These instructions should work for any project that is able to run figwheel from the command line using a `lein run` command
+
+Add a `dev` folder to your project, then add a `user.clj` file in that folder and copy this code into it 
+
+```
+(require '[figwheel.main.api :as fig])
+(fig/start "dev")
+```
+
+Now we can get our REPL configured. In the Cursive menu, follow these steps
+
+* Navigate to `Run -> Edit Configurations`
+* Click the `+` icon and select `Clojure REPL ->  Local`
+* Select `Use clojure.main in normal JVM process` 
+* Enter `dev/user.clj` into the parameters field. 
+* Click `OK` to save the config.
+
+Run your REPL and enjoy figwheel-main in Cursive! Note that this will be a ClojureScript REPL - we will see how to get things working nicely with a combined Clojure + ClojureScript project next.
+
+[create-a-build]: https://figwheel.org/docs/create_a_build.html


### PR DESCRIPTION
This covers getting figwheel-main started using Leiningen for CLJS projects - I'm planning to add a section for combined CLJ and CLJS projects next.

CLI integration with Cursive is quite new and does not work with figwheel-main at this point, but I expect it will be fixed in the next EAP or full release (latest is 1.8.0-eap7) and I plan to add documentation for that once it is working.