### PR TITLE
Correct :css-dirs example to use "resources/"

### DIFF
--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -56,7 +56,7 @@ namespace tree `src/cljs`.
 
 A list of CSS source directories to be watched and reloaded into the browser.
 
-    :css-dirs ["resource/public/css"]
+    :css-dirs ["resources/public/css"]
 
 ## :ring-handler
 


### PR DESCRIPTION
This is the convention everywhere else in the docs