### PR TITLE
Use canonical paths for css reload

### DIFF
--- a/src/figwheel/main/css_reload.cljc
+++ b/src/figwheel/main/css_reload.cljc
@@ -179,9 +179,9 @@
              (json/write-str files)))))
 
 (defn prep-css-file-path [file]
-  (->> file
-       fw-util/relativized-path-parts
-       (string/join "/")))
+  (-> file
+      .getCanonicalPath
+      (string/replace java.io.File/separator "/")))
 
 ;; repl-env needs to be bound
 (defn start* [paths]


### PR DESCRIPTION
instead of paths 'relativized' from working directory.
This fixes css reloading when canonicalized :css-dirs are outside of
the working directory.
It's ok to use the entire absolute path for file names to reload, since
the figwheel client locates css link tags to replace by matching reversed
lists of path segments (see figwheel.main.css-reload/matches-file?).