### PR TITLE
Fix documentation for --serve CLI argument

### DIFF
--- a/helper-content/server_only_welcome.md
+++ b/helper-content/server_only_welcome.md
@@ -3,7 +3,7 @@
 You are here because you launched `figwheel.main` in server only mode
 **and** you have not provided a default `index.html` file.
 
-**Server only mode** is entered when specify `--server` or
+**Server only mode** is entered when specify `--serve` or
 `-s` as the only **main option** to `figwheel.main`.
 
 **Server only mode** only serve files and ring endpoints defined

--- a/helper-resources/public/com/bhauman/figwheel/helper/content/server_only_welcome.html
+++ b/helper-resources/public/com/bhauman/figwheel/helper/content/server_only_welcome.html
@@ -4,7 +4,7 @@
 <p>You are here because you launched <code>figwheel.main</code> in server only mode
 <strong>and</strong> you have not provided a default <code>index.html</code> file.</p>
 
-<p><strong>Server only mode</strong> is entered when specify <code>--server</code> or
+<p><strong>Server only mode</strong> is entered when specify <code>--serve</code> or
 <code>-s</code> as the only <strong>main option</strong> to <code>figwheel.main</code>.</p>
 
 <p><strong>Server only mode</strong> only serve files and ring endpoints defined

--- a/src/figwheel/main.cljc
+++ b/src/figwheel/main.cljc
@@ -686,10 +686,10 @@ classpath. Classpath-relative paths have prefix of @ or @/")
                      "The --build option will make an "
                      "extra attempt to "
                      "initialize a figwheel live reloading workflow. "
-                     "May be followed buy either --repl or --server. "
+                     "May be followed buy either --repl or --serve. "
                      "If --repl follows, "
                      "will launch a REPL (along with a server) after the compile completes. "
-                     "If --server follows, will only start a web server according to "
+                     "If --serve follows, will only start a web server according to "
                      "current configuration after the compile "
                      "completes.")}
           ["-bo" "--build-once"]
@@ -699,7 +699,7 @@ classpath. Classpath-relative paths have prefix of @ or @/")
                      "Looks for build EDN files just like the --build command. "
                      "This will not inject Figwheel or REPL functionality into your build. "
                      "It will still inject devtools if you are using :optimizations :none. "
-                     "If --server follows, will start a web server according to "
+                     "If --serve follows, will start a web server according to "
                      "current configuration after the compile "
                      "completes.")}
           ["-r" "--repl"]

--- a/src/figwheel/main/schema/cli.clj
+++ b/src/figwheel/main/schema/cli.clj
@@ -731,7 +731,7 @@ main options:
    -c, --compile [ns]         Run a compile. If optional namespace specified,
                               use as the main entry point. If --repl follows,
                               will launch a REPL after the compile completes.
-                              If --server follows, will start a web server that
+                              If --serve follows, will start a web server that
                               serves the current directory after the compile
                               completes.
    -h, --help, -?             Print this help message and exit


### PR DESCRIPTION
The option was called `--serve`, but the documentation referred to `--server`.