### PR TITLE
Improve docs regarding Leiningen uberjar and resource paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,17 +313,33 @@ Ensure your `project.clj` file has `figwheel.main` dependencies:
 ```clojure
 :dependencies [[com.bhauman/figwheel-main "0.2.0"]
                [com.bhauman/rebel-readline-cljs "0.1.4"]]
- ;; setup target as a resource path
-:resource-paths ["target" "resources"]
 ;; set up an alias to invoke your figwheel build
 :aliases {"fig" ["trampoline" "run" "-m" "figwheel.main"]
           "build-dev" ["trampoline" "run" "-m" "figwheel.main" "-b" "dev" "-r"]}
 ```
 
+If you worked with the "old" figwheel, remember that it placed all
+compiled files into `resources/public/js`? Figwheel-main puts these in
+`target` instead.
+
+To serve these through the development web server of figwheel-main,
+they need to be on the resource path.
+
+In Leiningen, this leaves us with two options: The first idea would be
+to add `target` to the `:resource-paths` in your `project.clj`. This
+however creates a problem when compiling an uberjar: It would be
+infinitely large! That's because an uberjar includes all resources
+which are in target and the half-baked uberjar is in target, too!
+
+The better way is to configure figwheel-main to output compiled files
+into `resources`, for example to `resources/public/js`, like old
+figwheel.
+
 Create a `dev.cljs.edn` build file:
 
 ```clojure
-{:main example.core}
+{:main example.core
+ :output-dir "resources/public/js}
 ```
 
 In `src/example/core.cljs`, place the following ClojureScript code:

--- a/docs/docs/classpaths.md
+++ b/docs/docs/classpaths.md
@@ -371,6 +371,13 @@ violating a Leiningen failsafe.
 If you call `lein classpath` you will now see that `target` is indeed
 on the classpath.
 
+**A note about uberjars**
+
+Be careful setting `:resource-paths` to include `target` when
+compiling an uberjar - it will be infinitely large! Instead, prefer to
+edit your figwheel-main config changing `:output-dir` to some
+subdirectory of resources, for example `resources/public/js`.
+
 > Learn more about
 > [Leiningen profiles here][lein-profiles] or with the lein command
 > `lein help profiles`

--- a/docs/docs/create_a_build.md
+++ b/docs/docs/create_a_build.md
@@ -73,6 +73,13 @@ The contents of the `src/hello_world/core.cljs` file should be:
 (js/console.log "Hello there world!")
 ```
 
+**A note about uberjars**
+
+Be careful setting `:resource-paths` to include `target` when
+compiling an uberjar - it will be infinitely large! Instead, prefer to
+edit your figwheel-main config changing `:output-dir` to some
+subdirectory of resources, for example `resources/public/js`.
+
 ## Configuring a build
 
 The ClojureScript compiler can take a fairly extensive set of


### PR DESCRIPTION
## Problem

 * In Leiningen, including `target` in `:resource-paths` (in `project.clj`) is good because we want to  serve compiled js files and figwheel-main outputs those to `target`.
 * For uberjars however, this poses a problem as the half-baked uberjar is also in `target` and will try to include all resources which are, you guessed it, also in `target`. The uberjar will be infinitely large.

## Solution

 * For Leiningen, change the figwheel-main config instead; set `:output-dir` to something else (e.g. `resources/public/js`) and drop the `target` in `:resource-paths` (in `project.clj`).
 * Add that to the readme.
 * Add notes to the docs in relevant places.

Closes #134.