### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/docs/build_inputs.md
+++ b/docs/docs/build_inputs.md
@@ -28,8 +28,8 @@ initial sources, the compiler will then attempt to find it on the
 classpath.
 
 If you provide a single file to the compiler like
-`src/example/core.cljs` only that file will in the intial sources and
-all it's depedencies will be resovled via the classpath.
+`src/example/core.cljs` only that file will in the initial sources and
+all it's dependencies will be resolved via the classpath.
 
 This behavior has various trade-offs that need to be understood in the
 context of compiling for development and production.
@@ -41,7 +41,7 @@ code base will only include code that is needed by the application.
 
 Its a temptingly simple heuristic that works for many cases. But let
 me make an argument why it is better to pass a directory or set of
-directories to the compiler during developement when you are using a
+directories to the compiler during development when you are using a
 hot reloading workflow.
 
 The biggest reason to have all you files under watch while you are
@@ -68,7 +68,7 @@ compile.
 It is for the above reasons that both `figwheel.main` and `cljs.main`
 supply the watched directories to the compiler. They are being watched
 so there is an expectation of feedback, when there is no feedback on
-can mistakely assume that the code one is writing has no syntax
+can mistakenly assume that the code one is writing has no syntax
 errors.
 
 ## Production
@@ -81,11 +81,11 @@ level `:whitespace` we don't want it contain unneeded namespaces.
 
 `figwheel.main` uses the file containing your `:main` namespace as the
 single build input when you are not in `:optimizations` level
-`:none`. This will esnure that the deployed bundle of JavaScript only
+`:none`. This will ensure that the deployed bundle of JavaScript only
 contains code that is being depended on.
 
 This is less of a problem when you use the `:advanced` level as it
-will perfom dead code elimination from the final artifact.
+will perform dead code elimination from the final artifact.
 
 ## Overriding build inputs
 

--- a/docs/docs/classpaths.md
+++ b/docs/docs/classpaths.md
@@ -353,11 +353,11 @@ Unfortunately I'm not going to fully explain the changes to your
 
 
 The following config is going to add a path to your classpath in
-developement mode so that the files don't get added to your deployed
+development mode so that the files don't get added to your deployed
 uberjar. It's going to use the `:resource-paths` because it seems to
 be the most appropriate considering how we are using it. We are also
 making an adjustment so that we can call `lein clean` without
-violating a Leiningen failsafe.
+violating a Leiningen fail-safe.
 
 ```clojure
 (defproject example-project "0.1.0-SNAPSHOT"

--- a/docs/docs/code_splitting.md
+++ b/docs/docs/code_splitting.md
@@ -98,7 +98,7 @@ Edit this file to look like the following:
 > I altered the original example to make it
 > [reloadable][reloadable-code] and so that it works with the DOM on
 > the Figwheel default dev page. I also added [`^:figwheel-load`
-> metatdata][figwheel-load] to the namespace so that I can easily load the file into
+> metadata][figwheel-load] to the namespace so that I can easily load the file into
 > my environment by saving it.
 
 Create the `bar.core` namespace:

--- a/docs/docs/compile_config.md
+++ b/docs/docs/compile_config.md
@@ -155,7 +155,7 @@ target/public/cljs-out/dev
 These files also serve as a cache for the compiler which enables
 incremental compiles. If your source file has a timestamp newer than
 the file in the output directory, then the compiler will compile the
-sourcefile. Caches can get stale however and you will want to **delete
+source file. Caches can get stale however and you will want to **delete
 your output directory on a regular basis**.
 
 When no `:output-dir` is defined, Figwheel will provide a default
@@ -302,7 +302,7 @@ runtime environment.
 
 Figwheel takes advantage of this to inject its code into your
 environment. You can see this in the `hello-world.core` example
-project above. Fighweel appended several `:preloads` to the
+project above. Figwheel appended several `:preloads` to the
 configuration:
 
 ```clojure
@@ -318,7 +318,7 @@ All of these namespaces add additional functionality to your
 application. Notice that this is how we add `devtools` and the
 `figwheel.repl` connection to your build.
 
-You can add preloads as well to add behavior to your development or
+You can add pre-loads as well to add behavior to your development or
 production builds.
 
 ## The `:closure-defines` option
@@ -348,7 +348,7 @@ can override these default values in our configuration with the
                   hello-world.core/LOCALE "fr"}
 ```
 
-Figwheel uses `:closure-defines` to supply the connection url to the
+Figwheel uses `:closure-defines` to supply the connection URL to the
 `figwheel.repl` connection code.
 
 You can see in our example above that its value is:

--- a/docs/docs/cursive.md
+++ b/docs/docs/cursive.md
@@ -19,7 +19,7 @@ We're going to start with the same build that we used in the [create-a-build] do
 ```shell
 $ lein fig -- -b dev -r
 ```
-> These instructions should work for any project that is able to run figwheel from the command line using a `lein run` command
+> These instructions should work for any project that is able to run Figwheel from the command line using a `lein run` command
 
 Add a `dev` folder to the root of your project, then add a `user.clj` file in that folder and copy this code into it 
 

--- a/docs/docs/editor-integration.md
+++ b/docs/docs/editor-integration.md
@@ -122,7 +122,7 @@ result of the evaluation.
 
 ## Editors and nREPL
 
-Almost all editor integrations in the ClojureScript eco-system can
+Almost all editor integrations in the ClojureScript ecosystem can
 utilize nREPL for communication. This is why understanding it and its
 role as a REPL server is important.
 

--- a/docs/docs/emacs.md
+++ b/docs/docs/emacs.md
@@ -58,7 +58,7 @@ Personally, I am not an Emacs expert, I tend to use a very small set
 of commands when I'm using Emacs. I tend to use the commands that are
 available universally in text buffers and shell line readers. I do
 tend use more commands when I'm creating Emacs macros to automate an
-otherwise repetative operation to transform some text.
+otherwise repetitive operation to transform some text.
 
 ## Installing CIDER
 

--- a/docs/docs/getting_help.md
+++ b/docs/docs/getting_help.md
@@ -43,9 +43,9 @@ try to learn ClojureScript.
 ### Trying to learn to much
 
 First, folks try to learn too many things in parallel. They try to
-learn functional programming, persistent datastructures, ClojureScript
+learn functional programming, persistent data structures, ClojureScript
 tooling, hot reloading, using a browser connected REPL, Reactjs, a
-ClojureScript React wrapper like Reagent, Javascript, Ring(ie. Rack
+ClojureScript React wrapper like Reagent, Javascript, Ring (i.e. Rack
 for Clojure), setting up a Clojure webserver all at the same time.
 
 This layering strategy may be an efficient way to learn when one is
@@ -62,7 +62,7 @@ The solution is to keep things as simple as possible when you start
 out. Choose finite challenges like learning enough of the
 ClojureScript language to where you can
 [express complex things](http://www.4clojure.com/) before you attempt
-to manipulate a web page. From there attempt to simply manipuate the
+to manipulate a web page. From there attempt to simply manipulate the
 DOM with the
 [`goog.dom` API](https://google.github.io/closure-library/api/goog.dom.html). Once
 you have a handle on that start exploring

--- a/docs/docs/hot_reloading.md
+++ b/docs/docs/hot_reloading.md
@@ -154,7 +154,7 @@ First, don't forget to add the `^:figwheel-hooks` annotation to the namespace:
 
 Then add an `^:after-load` marked function that will render the UI. In
 most cases you can reuse the "mount" function that rendered the UI for
-the first time. For example, to get Reagent to rerender you'd write:
+the first time. For example, to get Reagent to re-render you'd write:
 
 ```
 ;; this is what you call for the first mount

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -90,7 +90,7 @@ First we will want to [install][cli-tools] the `clj` and `clojure` [command line
 tools][cli-tools].
 
 If you are on Mac OSX and you can quickly install the Clojure tools
-via [homebrew][brew].
+via [Homebrew][brew].
 
 In the terminal at the shell prompt enter:
 
@@ -256,7 +256,7 @@ $ lein fig
 ```
 
 One thing that is very important to remember is that if you want to
-pass additional figwheel CLI options to the `lein fig` command above
+pass additional Figwheel CLI options to the `lein fig` command above
 you will have to add a `--` before the additional arguments.
 
 Let's display the Figwheel help documentation with the `-h` (or `--help`) option:

--- a/docs/docs/jetty_conflicts.md
+++ b/docs/docs/jetty_conflicts.md
@@ -35,7 +35,7 @@ start a build with `figwheel.main` with fail with
 java.lang.NoClassDefFoundError: org/eclipse/jetty/http/HttpParser$ProxyHandler
 ```
 
-This is due to a dependency missmatch between Jetty deps.
+This is due to a dependency mismatch between Jetty deps.
 
 The most sure fire way to fix this error is to explicitly specify all
 the Jetty dependencies in your project and ensure they are all the
@@ -63,7 +63,7 @@ The next time you start Figwheel the error should be gone.
 You can detect these conflicts by looking at the dependency tree of
 your application.
 
-Leinigen has excellent support for pointing out these conflicts.
+Leiningen has excellent support for pointing out these conflicts.
 
 If you are using Leiningen then you can run the `lein deps :tree`
 command.
@@ -76,7 +76,7 @@ time to examine that as well.
 
 ### with Clojure CLI tools
 
-Clojure CLI tools doesn't have the helpful output that Leinigen
+Clojure CLI tools doesn't have the helpful output that Leiningen
 currently supplies. It can print out the dependency tree:
 
 ```

--- a/docs/docs/main_script.md
+++ b/docs/docs/main_script.md
@@ -8,7 +8,7 @@ order: 18
 # Main Scripts
 
 <div class="lead-in">Just like <code>cljs.main</code>, the Figwheel allows you to
-run a <code>-main</code> function in a namesapce from the command line. Figwheel
+run a <code>-main</code> function in a namespace from the command line. Figwheel
 provides additional functionality to facilitate asynchronous execution
 and process failure.</div>
 
@@ -74,7 +74,7 @@ $ clj -m figwheel.main -co dev.cljs.edn -m example.hello
 
 This `--main` CLI option behavior is unfortunately hampered in its
 ability to be useful because many ClojureScript tasks (including
-running tests) are asynchonous. Not only that, but we'd prefer that if
+running tests) are asynchronous. Not only that, but we'd prefer that if
 a command line task execution fails in ClojureScript we'd like that
 failure to be communicated by returning a non-zero exit status from
 the `clj` process.
@@ -90,7 +90,7 @@ error to cause a non-zero exit from the Clojure process.
 What do we do when the process is asynchronous?
 
 `figwheel.main` extends the `cljs.main` behavior to provide a means of
-waiting for an asynchronus process to complete or throw an error.
+waiting for an asynchronous process to complete or throw an error.
 
 The following 3 tools help you do this:
 
@@ -124,7 +124,7 @@ $ clj -m figwheel.main -m example.hello
 ```
 
 The Clojure process will block for 5 seconds while it waits for some
-asynchronus result to be sent back. In this example we are not sending
+asynchronous result to be sent back. In this example we are not sending
 back a result value, so the process will throw a timed-out exception
 which will cause a non-zero exit.
 
@@ -150,7 +150,7 @@ Now the Clojure process will block for 3 seconds and ultimately print
 out the value of `args` sent by the `figwheel.main.async-result/send`
 function.
 
-Let's modify the namespace one more time to send an asynchronus
+Let's modify the namespace one more time to send an asynchronous
 failure:
 
 ```clojure

--- a/docs/docs/npm.md
+++ b/docs/docs/npm.md
@@ -343,7 +343,7 @@ If you want, Figwheel will try to read your `index.js` file and
 generate a `:foreign-libs` entry for you. This is intended to help cut
 out some of the pain of consuming NPM libraries.
 
-The [`:npm` figwheel option](../config-options#npm) will do this for
+The [`:npm` Figwheel option](../config-options#npm) will do this for
 you. Here is an example of the configuration in our `dev.cljs.edn`
 before and after using the `:npm` key.
 

--- a/docs/docs/reloadable_code.md
+++ b/docs/docs/reloadable_code.md
@@ -99,7 +99,7 @@ the `defonce` is only invoked the first time it is evaluated. If
 `add-body-listeners` returns a truthy value we don't have to provide
 the `true` at the end.
 
-Running your initialization code the first time the a page loads can
+Running your initialization code the first time the page loads can
 also be accomplished by registering a `load` handler on window.
 
 ```clojure

--- a/docs/docs/ring-handler.md
+++ b/docs/docs/ring-handler.md
@@ -56,7 +56,7 @@ provides a good summary of how Ring works.
 ## The last handler
 
 The Figwheel server has a chain of middleware that helps it do its
-job, this chain of middlewared is composed on top of the popular
+job, this chain of middleware is composed on top of the popular
 [`ring-defaults`](https://github.com/ring-clojure/ring-defaults)
 middleware stack.
 

--- a/docs/docs/scripting_api.md
+++ b/docs/docs/scripting_api.md
@@ -81,7 +81,7 @@ REPL via `:cljs/quit` and then restart it by calling
 
 ## REPL switching example
 
-For this example to work, one will need to set up the normal figwheel
+For this example to work, one will need to set up the normal Figwheel
 dependencies along with `com.bhauman/rebel-readline-cljs`.
 
 We'll start off by starting a Rebel Readline Clojure REPL.

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -10,7 +10,7 @@ order: 19
 <div class="lead-in"><p>Testing is an important part of any
 programming workflow. Having tests that run after every code change is
 essential and should not be hard to set up.</p> <p>Figwheel now
-provides <a href="#auto-testing">automatic test discovery and display</a>, faciliates custom
+provides <a href="#auto-testing">automatic test discovery and display</a>, facilitates custom
 testing with <a href="extra_mains">Extra Main</a> entry points, complements build
 processes and CI with non-zero test run failures, and provides
 a flexible way to configure an alternative JS environment to run your
@@ -44,7 +44,7 @@ with the following keys:
 ## Custom testing with `:extra-main-files`
 
 If the testing setup provided by [`:auto-testing`][auto-testing]
-doesn't work for you. The [extra mains](extra_mains) feature has you
+doesn't work for you, the [extra mains](extra_mains) feature has you
 covered. We'll quickly walk through an example of using
 [`:extra-main-files`][extra-main-files] to provide a custom testing
 setup with relatively little effort.

--- a/docs/docs/vim.md
+++ b/docs/docs/vim.md
@@ -40,7 +40,7 @@ and folders:
         └── main.cljs
 ```
 
-The following is a minimal figwheel dev config, `dev.cljs.edn`:
+The following is a minimal Figwheel dev config, `dev.cljs.edn`:
 
 ```clojure
 ^{:watch-dirs ["src"]}
@@ -99,7 +99,7 @@ cursor over a symbol in Vim and press `K` to see its doc string. If
 you get an immediate result, you have successfully connected to the
 nREPL server.
 
-Now we can start figwheel:
+Now we can start Figwheel:
 
 ```clojure
 user=> (require 'figwheel.main.api)
@@ -115,7 +115,7 @@ Some log messages will appear including something like:
 
 Open your browser to this URL. This is the default Figwheel dev host
 page.  A green "Connected" image should appear at the top-left
-indicating a successful connection between the browser and figwheel.
+indicating a successful connection between the browser and Figwheel.
 
 Back in the Clojure REPL, we're now ready to start a ClojureScript REPL
 within.

--- a/docs/docs/your_own_page.md
+++ b/docs/docs/your_own_page.md
@@ -16,7 +16,7 @@ host page, but sooner or later you will want to supply your own.</div>
 Figwheel starts a server when it launches a build and/or a REPL. The
 primary purpose of this server is to provide websocket communication
 between the REPL and the client environment. Figwheel not only uses
-this connection to evalute compiled REPL expressions, it also uses it
+this connection to evaluate compiled REPL expressions, it also uses it
 to communicate hot reloads, compile errors, and other things.
 
 The secondary use of this server is as an initial development HTTP
@@ -200,7 +200,7 @@ page.
 
 Fancy eh?
 
-Now we'll configure figwheel to embed the handler with the
+Now we'll configure Figwheel to embed the handler with the
 [`:ring-handler` config option][ring-handler] in our build file.
 
 Let's configure the ring handler in our example `dev.cljs.edn`:


### PR DESCRIPTION
I found the docs an excellent resource to learn the figwheel-main. While reading them I stumbled upon a few typos that I fixed in this pull request.