### PR TITLE
Adds a proposed emphatic note to the Vim help

### DIFF
--- a/docs/docs/vim.md
+++ b/docs/docs/vim.md
@@ -138,6 +138,11 @@ user=> (js/alert "Hello from the ClojureScript REPL")
 
 If you see a pop-up dialog in your browser, it worked!
 
+> You *must* start this ClojureScript REPL before Piggieback can connect.
+> Unlike other ClojureScript REPLs that Piggieback can start entirely on its
+> own given just an nREPL port, the ClojureScript REPL within Vim relies on
+> *both* nREPL and this primary ClojureScript REPL.
+
 Now let's connect fireplace. Run this command in Vim while in a
 ClojureScript buffer:
 


### PR DESCRIPTION
Yes, starting the repl first _is_ implied in these docs and the repl-env docstring.

The trouble for me came in that it seems Piggieback sometimes will and sometimes won't start up a cljs-repl on its own given a repl-env. I got to assuming that `:Piggieback (figwheel.main.api/repl-env "dev")` in vim was roughly equivalent to starting the cljs-repl in the clj-repl.

I'm presuming others might run into this confusion, and want to make the right thing to do more explicit.