### PR TITLE
Fix a small typo in documentation

### DIFF
--- a/docs/docs/classpaths.md
+++ b/docs/docs/classpaths.md
@@ -209,7 +209,7 @@ that looks like this:
 
 Place this code in `src/hello_world/core.cljs`:
 ```clojure
-(ns hello-world/core.cljs)
+(ns hello-world.core)
 
 (js/console.log "Hello World!")
 ```


### PR DESCRIPTION
Was going through docs and noticed a small typo.