### PR TITLE
Add Hawk Options to CSS watcher

### DIFF
--- a/src/figwheel/main.cljc
+++ b/src/figwheel/main.cljc
@@ -1187,17 +1187,18 @@ classpath. Classpath-relative paths have prefix of @ or @/")
                         (fn [p] (vec (distinct (concat p '[figwheel.main.evalback #_figwheel.main.testing]))))))
          cfg))
 
-     (defn watch-css [css-dirs]
+     (defn watch-css [css-dirs & [reload-config]]
        (when-let [css-dirs (not-empty css-dirs)]
          (when-let [start-css (fw-util/require-resolve-var 'figwheel.main.css-reload/start*)]
-           (start-css css-dirs))))
+           (start-css css-dirs reload-config))))
 
      (defn config-watch-css [{:keys [::config options] :as cfg}]
        (cond-> cfg
          (and (not-empty (:css-dirs config))
               (repl-connection? cfg))
          (->
-          (update ::initializers (fnil conj []) #(watch-css (:css-dirs config)))
+          (update ::initializers (fnil conj [])
+                  #(watch-css (:css-dirs config) (config->reload-config config)))
           (update-in [:options :preloads]
                      (fn [p] (vec (distinct (conj p 'figwheel.main.css-reload))))))))
 

--- a/src/figwheel/main/css_reload.cljc
+++ b/src/figwheel/main/css_reload.cljc
@@ -177,16 +177,18 @@
            (string/replace java.io.File/separator "/")))
 
 ;; repl-env needs to be bound
-     (defn start* [paths]
-       (fww/add-watch!
-        [::watcher paths]
-        {:paths paths
-         :filter (fww/suffix-filter #{"css"})
-         :handler (fww/throttle
-                   50
-                   (bound-fn [evts]
-                     (when-let [files (not-empty (mapv (comp prep-css-file-path :file) evts))]
-                       (reload-css-files files))))}))
+     (defn start* [paths & [reload-config]]
+       (binding
+         [fww/*hawk-options* (:hawk-options reload-config nil)]
+         (fww/add-watch!
+           [::watcher paths]
+           {:paths paths
+            :filter (fww/suffix-filter #{"css"})
+            :handler (fww/throttle
+                       50
+                       (bound-fn [evts]
+                         (when-let [files (not-empty (mapv (comp prep-css-file-path :file) evts))]
+                           (reload-css-files files))))})))
 
      (defn stop* [paths]
        (let [remove-watch! (resolve 'figwheel.main/remove-watch!)]


### PR DESCRIPTION
  Hawk Options are now being passed through the css reload start watch
   which was breaking polling options.

Fixes Issue #207 