### PR TITLE
Issues #169 #213 figwheel does not start

### DIFF
--- a/docs/docs/your_own_server.md
+++ b/docs/docs/your_own_server.md
@@ -106,7 +106,8 @@ file at `scripts/server.clj` with the following content:
 
 (run-jetty
  (wrap-defaults handler site-defaults)
- {:port 4000})
+ {:port 4000
+  :join? false})
 ```
 
 The above Clojure file defines a Ring handler and runs the server when


### PR DESCRIPTION
The complaints are that figwheel does not start. I figure that the (run-jetty) call is blocking. So either put the whole call in a (future) or change the :join? to false. Not sure which is better or any implication. For your consideration.