### PR TITLE
Update expound and fix incompatibilities.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
    [org.eclipse.jetty.websocket/websocket-server  "9.4.12.v20180830"]
    [binaryage/devtools "0.9.10"]
    [hawk "0.2.11"]
-   [expound "0.7.1"]]
+   [expound "0.8.4"]]
   :resource-paths ["helper-resources"]
   :profiles {:dev {:dependencies [[cider/piggieback "0.3.9"]
                                   #_[com.bhauman/rebel-readline-cljs "0.1.4"]]

--- a/src/figwheel/main.cljc
+++ b/src/figwheel/main.cljc
@@ -208,7 +208,7 @@
                     (:validate-config
                      edn
                      (get-edn-file-key "figwheel-main.edn" :validate-config)))))
-         (expound.ansi/with-color-when (:ansi-color-output edn true)
+         (binding [expound.ansi/*enable-color* (:ansi-color-output edn true)]
            (validate-config!* spec edn fail-msg))
          (when succ-msg
            (log/succeed succ-msg))))
@@ -220,8 +220,8 @@
      (defn validate-cli! [cli-args & [succ-msg]]
        (when (and validate-cli!*
                   (get-edn-file-key "figwheel-main.edn" :validate-cli true))
-         (expound.ansi/with-color-when
-           (get-edn-file-key "figwheel-main.edn" :ansi-color-output true)
+         (binding [expound.ansi/*enable-color*
+                   (get-edn-file-key "figwheel-main.edn" :ansi-color-output true)]
            (validate-cli!* cli-args "Error in command line args"))
          (when succ-msg
            (log/succeed succ-msg))))


### PR DESCRIPTION
Hi!

As #227 issue explans, figwheel is broken with latest version of expound. This change should fix it.