### PR TITLE
Change note about CLI Tools on Windows

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -60,9 +60,7 @@ This document is going to prefer [CLI Tools][cli-tools] because:
 
 **On Windows**
 
-As of this writing [CLI Tools][cli-tools] is not available on the
-Windows Operating System yet. For now, if you are on Windows you will
-need to use [Leiningen][lein].
+As of this writing [CLI Tools][cli-tools] on Windows is in an alpha state. For now, if you are on Windows you may want to use [Leiningen][lein].
 
 ## Install your tool of choice
 


### PR DESCRIPTION
The CLI Tools are available on Windows now in an alpha state. I've used the CLI Tools on Windows for the Figwheel tutorial and it's been working fine. Since it's currently in an alpha state I don't know if you want to remove the section "On Windows" or just change it to something like I did.