### PR TITLE
Treat descendants of classpath dir as classpath

### DIFF
--- a/src/figwheel/main/util.clj
+++ b/src/figwheel/main/util.clj
@@ -133,13 +133,16 @@
 #_(add-classpath! (.toURL (io/file "src")))
 
 (defn dir-on-classpath? [dir]
-  ((set (static-classpath)) (.getCanonicalPath (io/file dir))))
+  (let [dir-canonical-path (.getCanonicalPath (io/file dir))]
+    (some #(.startsWith dir-canonical-path %) (static-classpath))))
 
 (defn dir-on-current-classpath? [dir]
-  ((into #{}
-         (concat
-          (static-classpath)
-          (dynamic-classpath))) (.getCanonicalPath (io/file dir))))
+  (let [dir-canonical-path (.getCanonicalPath (io/file dir))]
+    (some #(.startsWith dir-canonical-path %)
+          (distinct
+            (concat
+              (static-classpath)
+              (dynamic-classpath))))))
 
 (defn root-dynclass-loader []
   (last

--- a/test/figwheel/main/util_test.clj
+++ b/test/figwheel/main/util_test.clj
@@ -1,0 +1,15 @@
+(ns figwheel.main.util-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [figwheel.main.util :as sut]))
+
+(deftest dir-on-classpath?
+  (is (sut/dir-on-classpath? "src"))
+  (is (sut/dir-on-classpath? "src/foo")
+      "Since src dir is on classpath then anything inside it should be on classpath too")
+  (is (not (sut/dir-on-classpath? "blah"))))
+
+(deftest dir-on-current-classpath?
+  (is (sut/dir-on-current-classpath? "src"))
+  (is (sut/dir-on-current-classpath? "src/foo")
+      "Since src dir is on classpath then anything inside it should be on classpath too")
+  (is (not (sut/dir-on-current-classpath? "blah"))))


### PR DESCRIPTION
Hello!
Here in Magnet we noticed that figwheel complained about a path not being on classpath despite the that that it was held in `resources/` that were added to resources path. Then we found the issue #221 that we believe is the same thing. We came up with this solution where we not only check for exact match in classpath but for any known classpath that is a (0, x) substring of the canonical path in question.

[Re #221]