### PR TITLE
Switched JS syntax export style in figwheel-bridge.js to fix react-native-web

### DIFF
--- a/helper-resources/com/bhauman/figwheel/react-native-figwheel-bridge/figwheel-bridge.js
+++ b/helper-resources/com/bhauman/figwheel/react-native-figwheel-bridge/figwheel-bridge.js
@@ -151,7 +151,7 @@ function shimRequire(requireMap) {
 // deprecated
 // this will not work when you use react native expo
 // use createBridgeComponent instead
-function startApp(options){
+function start(options){
   assert(options.appName, "must provide an appName");
   assertKeyType(options, "appName", "string");
   // The crux of the loading problem for React Native is that the code needs to be loaded synchronously
@@ -162,8 +162,8 @@ function startApp(options){
   ReactNative.AppRegistry.registerComponent(options.appName, () => createBridgeComponent(options));
 }
 
-module.exports = {
-  shimRequire: shimRequire,
-  start: startApp,
-  createBridgeComponent: createBridgeComponent
-};
+export {
+  shimRequire,
+  start,
+  createBridgeComponent
+}


### PR DESCRIPTION
When trying to run react-native-web (https://github.com/necolas/react-native-web) I got the following error:

<img width="400" alt="Screen Shot 2021-02-25 at 7 08 51 PM" src="https://user-images.githubusercontent.com/3014532/109249620-eaa1ae00-779c-11eb-8654-2ef1549b6ec3.png">

Was able to fix by switching to the ES Modules export syntax. Tested on iOS native app and web. 