### PR TITLE
fix #314: avoid false warnings by bump devtools

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -16,7 +16,7 @@
         com.nextjournal/beholder {:mvn/version "1.0.0"}
 
         ;; possibly external
-        binaryage/devtools {:mvn/version "1.0.4"}
+        binaryage/devtools {:mvn/version "1.0.5"}
 
         ;; going to make validation seperate?
         expound/expound {:mvn/version "0.7.0"}


### PR DESCRIPTION
Root cause is an unfixed bug introduced into ClojureScript.
devtools has a workaround.
Updating to 1.05
