### PR TITLE
Fix typo in config property

### DIFF
--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -624,7 +624,7 @@ Using :parsel this will set :bundle-cmd to:
 
 And it will also add
 
-    :clojure-defines {"cljs.core/*global*""window"}
+    :closure-defines {"cljs.core/*global*""window"}
 
 when using :optimizations :simple or :advanced.
 


### PR DESCRIPTION
It's closure-defines, not clojure-defines

And I'm sure that's the first and last time anyone ever will make that mistake!