### PR TITLE
Fix error in :closure-defines documentation

### DIFF
--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -624,7 +624,7 @@ Using :parsel this will set :bundle-cmd to:
 
 And it will also add
 
-    :closure-defines {"cljs.core/*global*""window"}
+    :closure-defines {cljs.core/*global* "window"}
 
 when using :optimizations :simple or :advanced.
 


### PR DESCRIPTION
The define should be a symbol, not a string.

Tested on my machine, no global variables were defined with `"cljs.core/*global*"`, worked fine with `cljs.core/*global*` :)