### PR TITLE
Revert "Fix typo in config property"

### DIFF
--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -624,7 +624,7 @@ Using :parsel this will set :bundle-cmd to:
 
 And it will also add
 
-    :closure-defines {"cljs.core/*global*""window"}
+    :clojure-defines {"cljs.core/*global*""window"}
 
 when using :optimizations :simple or :advanced.
 


### PR DESCRIPTION
Reverts bhauman/figwheel-main#326

Yeah this shouldn't be fixed here. As the top of the page states this file is generated from another file.  `src/figwheel/main/schema/core.clj`