### PR TITLE
Use client-hostname by default

### DIFF
--- a/doc/figwheel-main-options.md
+++ b/doc/figwheel-main-options.md
@@ -168,7 +168,7 @@ the server.
 This url is actually a template that will be filled in.  For example
 the default `:connect-url` is:
 
-    "ws://[[config-hostname]]:[[server-port]]/figwheel-connect"
+    "ws://[[client-hostname]]:[[server-port]]/figwheel-connect"
 
 The available template variables are:
 
@@ -655,7 +655,7 @@ This adds default `:ring-server-options` for
     :ssl-port 9533
 
 This also changes the default `:connect-url` to
-`wss://[[config-hostname]]:<ssl-port>/figwheel-connect` and the
+`wss://[[client-hostname]]:<ssl-port>/figwheel-connect` and the
 default `:open-url` to `https://[[server-hostname]]:<ssl-port>` where
 `<ssl-port>` is replaced with the `:ssl-port` from
 `:ring-server-options`.

--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -168,7 +168,7 @@ the server.
 This url is actually a template that will be filled in.  For example
 the default `:connect-url` is:
 
-    "ws://[[config-hostname]]:[[server-port]]/figwheel-connect"
+    "ws://[[client-hostname]]:[[server-port]]/figwheel-connect"
 
 The available template variables are:
 
@@ -655,7 +655,7 @@ This adds default `:ring-server-options` for
     :ssl-port 9533
 
 This also changes the default `:connect-url` to
-`wss://[[config-hostname]]:<ssl-port>/figwheel-connect` and the
+`wss://[[client-hostname]]:<ssl-port>/figwheel-connect` and the
 default `:open-url` to `https://[[server-hostname]]:<ssl-port>` where
 `<ssl-port>` is replaced with the `:ssl-port` from
 `:ring-server-options`.

--- a/docs/docs/https.md
+++ b/docs/docs/https.md
@@ -171,13 +171,13 @@ new certificates can be created for that trusted root.
 
 You'll want the connection to Figwheel to go over SSL so we'll need
 to change the [`:connect-url`](/config-options#connect-url) to
-`"wss://[[config-hostname]]:9533/figwheel-connect"`
+`"wss://[[client-hostname]]:9533/figwheel-connect"`
 
 You'll also want the browser that pops open after the build starts to
 be an `https` URL as well. You can do this by setting
 [`:open-url`](/config-options#open-url) to `"https://[[server-hostname]]:9533"`
 
-It's important to remember that both `[[config-hostname]]` and
+It's important to remember that both `[[client-hostname]]` and
 `[[server-hostname]]` are template variables that are filled in by
 Figwheel.
 
@@ -186,7 +186,7 @@ Figwheel.
 So our finished configuration will something like:
 
 ```clj
-^{:connect-url "wss://[[config-hostname]]:9533/figwheel-connect"
+^{:connect-url "wss://[[client-hostname]]:9533/figwheel-connect"
   :open-url "https://[[server-hostname]]:9533"
   :ring-server-options {:ssl? true
                         :ssl-port 9533

--- a/src/figwheel/main.cljc
+++ b/src/figwheel/main.cljc
@@ -1011,7 +1011,7 @@ classpath. Classpath-relative paths have prefix of @ or @/")
                            (assoc-in  [::config :ring-server-options :ssl-port] ssl-port)
                            (update-in [::config :ring-server-options :ssl?] (fnil identity true))
                            (update-in [::config :connect-url]
-                                      (fnil identity (format "wss://[[config-hostname]]:%d/figwheel-connect" ssl-port)))
+                                      (fnil identity (format "wss://[[client-hostname]]:%d/figwheel-connect" ssl-port)))
                            (update-in [::config :open-url]
                                       (fnil identity (format "https://[[server-hostname]]:%d" ssl-port))))]
                (if (or (get-in cfg [::config :ring-server-options :keystore])

--- a/src/figwheel/main/schema/config.clj
+++ b/src/figwheel/main/schema/config.clj
@@ -175,7 +175,7 @@ the server.
 This url is actually a template that will be filled in.  For example
 the default `:connect-url` is:
 
-    \"ws://[[config-hostname]]:[[server-port]]/figwheel-connect\"
+    \"ws://[[client-hostname]]:[[server-port]]/figwheel-connect\"
 
 The available template variables are:
 
@@ -763,7 +763,7 @@ This adds default `:ring-server-options` for
     :ssl-port 9533
 
 This also changes the default `:connect-url` to
-`wss://[[config-hostname]]:<ssl-port>/figwheel-connect` and the
+`wss://[[client-hostname]]:<ssl-port>/figwheel-connect` and the
 default `:open-url` to `https://[[server-hostname]]:<ssl-port>` where
 `<ssl-port>` is replaced with the `:ssl-port` from
 `:ring-server-options`.

--- a/src/figwheel/main/util.clj
+++ b/src/figwheel/main/util.clj
@@ -273,7 +273,7 @@
   (let [port (get-in config [:ring-server-options :port] figwheel.repl/default-port)
         host (get-in config [:ring-server-options :host] "localhost")]
     (fill-connect-url-template
-     (:connect-url config "ws://[[config-hostname]]:[[server-port]]/figwheel-connect")
+     (:connect-url config "ws://[[client-hostname]]:[[server-port]]/figwheel-connect")
      host
      port)))
 


### PR DESCRIPTION
This is more likely to be correct, that you want to connect back to the same hostname you connected to the application on.

The binding hostname that was used otherwise is more likely to be an internal IP such as 0.0.0.0 which is not a valid way to access the web anymore.

Fix https://github.com/bhauman/figwheel-main/issues/351